### PR TITLE
Disable delete to trash

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.osparc/metadata.yml
+++ b/.osparc/metadata.yml
@@ -2,7 +2,7 @@ name: JupyterLab SPARC
 key: simcore/services/dynamic/jupyterlab-sparc
 type: dynamic
 integration-version: 2.0.0
-version: 1.0.3
+version: 1.0.4
 description: JupyterLab with Python kernel and different SPARC-relevand tools installed, including the [SPARC Python Client](https://docs.sparc.science/docs/sparc-python-client) and Python dependencies from [Docker_SPARC](https://github.com/cchorn/Docker_SPARC).
 contact: iavarone@itis.swiss
 thumbnail: https://github.com/ITISFoundation/osparc-assets/blob/main/assets/jupyter-sparc.png?raw=true

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export VCS_STATUS := $(if $(shell git status -s 2> /dev/null || echo unversioned
 export BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 export DOCKER_IMAGE_NAME ?= jupyterlab-sparc
-export DOCKER_IMAGE_TAG ?= 1.0.3
+export DOCKER_IMAGE_TAG ?= 1.0.4
 
 OSPARC_DIR:=$(CURDIR)/.osparc
 

--- a/boot_scripts/boot_notebook.bash
+++ b/boot_scripts/boot_notebook.bash
@@ -49,7 +49,8 @@ cat > .jupyter_config.json <<EOF
         "token": "${NOTEBOOK_TOKEN}"
     },
     "FileContentsManager": {
-        "preferred_dir": "${NOTEBOOK_BASE_DIR}/workspace/"
+        "preferred_dir": "${NOTEBOOK_BASE_DIR}/workspace/",
+        "delete_to_trash": false
     }
 }
 EOF

--- a/boot_scripts/boot_notebook.bash
+++ b/boot_scripts/boot_notebook.bash
@@ -22,6 +22,7 @@ define(['base/js/namespace'], function(Jupyter){
 EOF
 
 # SEE https://jupyter-server.readthedocs.io/en/latest/other/full-config.html
+# disable delete_to_trash to avoid https://github.com/ITISFoundation/osparc-issues/issues/1296
 cat > .jupyter_config.json <<EOF
 {
     "FileCheckpoints": {

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,6 +1,6 @@
 services:
   jupyterlab-sparc:
-    image: simcore/services/dynamic/jupyterlab-sparc:1.0.3
+    image: simcore/services/dynamic/jupyterlab-sparc:1.0.4
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
## Problem
In recent Jupyterlab-based services, including the ones created with the new [cookiecutter for jupyterlabs](https://github.com/ITISFoundation/cookiecutter-osparc-jupyterlab-service), when the user deleted a file in the Jupyter UI, a `.Trash-1000` folder is created. Given the permissions on this folder, we can't push it to S3. More details in https://github.com/ITISFoundation/osparc-issues/issues/1296

## Investigations
It is not clear why this happens only in the newest Jupyters and not on other (e.g. jupyter-math). The "Trash" feature in jupyter seems relatively old (see https://github.com/jupyter/notebook/pull/1968).

## Solution
The JupyterLab Trash feature can be disabled via config. This is the only way I found to solve the issue, the only implication for the user is that if they delete a file via the UI, they won't be asked confirmation (it will work in the same way as deleting via the terminal with `rm`).

## Services affected
- jupyterlab-axondeepseg
- jupyterlab-sparc (this PR)
- jupyterlab-julia
- jupyterlab-R
- cookiecutter for jupyters


## Related issues
related to: https://github.com/ITISFoundation/osparc-issues/issues/1296. All the services listed above need to be fixed to resolve the issue